### PR TITLE
Make it work

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+const esModules = ['ant-design-vue', 'lodash-es'].join('|');
+
+module.exports = {
+  preset: '@vue/cli-plugin-unit-jest/presets/typescript-and-babel',
+  transform: {
+    '^.+\\.vue$': 'vue-jest',
+    [`(${esModules}).+\\.js$`]: 'babel-jest'
+  },
+  transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
+  moduleNameMapper: {
+    "\\.css$": "identity-obj-proxy",
+    "\\.css.js$": "identity-obj-proxy",
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "ant-design-vue": "^2.0.0-rc.5",
     "core-js": "^3.6.5",
+    "identity-obj-proxy": "^3.0.0",
     "vue": "^3.0.0"
   },
   "devDependencies": {

--- a/tests/unit/ant.spec.tsx
+++ b/tests/unit/ant.spec.tsx
@@ -1,9 +1,9 @@
 import Ant from '@/components/ant'
-import { shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 describe('Ant', () => {
     it("should be exists",()=>{
-        const wrapper = shallowMount(Ant)
+        const wrapper = mount(Ant)
         expect(wrapper.text()).toBe('ANT')
     })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",
+    "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
1. `npm install`
2. `yarn test:unit ant`

Should pass.

Notes:

- Jest does not understand ES modules. Ideally ANT Design team should provide a CJS (commonjs) build. Pls make an issue there asking them to do this.
- See jest.config.js. Updated to allow using babel-jest to transform some es modules in node_modules
- you cannot use `shallowMount` to test third party components - it will stub them out. Always use `mount`. Anyone who tells you to use `shallowMount` is wrong, it's basically a useless method that should never have been created in the first place.

Good luck!